### PR TITLE
Implement config.vendor.css

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -199,6 +199,22 @@ gulp.task('less', function () {
     .pipe(gulp.dest(path.join(config.dest, 'css')));
 });
 
+gulp.task('css-prepend', function() {
+  return gulp.src()
+    .pipe(concat('prepend.css'))
+    .pipe(cssmin())
+    .pipe(rename({suffix: '.min'}))
+    .pipe(gulp.dest(path.join(config.dest, 'css')));
+});
+gulp.task('css-append', function() {
+  return gulp.src(config.vendor.css.append)
+    .pipe(concat('append.css'))
+    .pipe(cssmin())
+    .pipe(rename({suffix: '.min'}))
+    .pipe(gulp.dest(path.join(config.dest, 'css')));
+});
+gulp.task('css', ['css-prepend', 'css-append'], function() {});
+
 
 /*====================================================================
 =            Compile and minify js generating source maps            =
@@ -256,7 +272,7 @@ gulp.task('weinre', function() {
 ======================================*/
 
 gulp.task('build', function(done) {
-  var tasks = ['html', 'fonts', 'images', 'less', 'js'];
+  var tasks = ['html', 'fonts', 'images', 'less', 'js', 'css'];
   seq('clean', tasks, done);
 });
 

--- a/app/templates/_index.html
+++ b/app/templates/_index.html
@@ -8,8 +8,10 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="viewport" content="user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimal-ui" />
     <meta name="apple-mobile-web-app-status-bar-style" content="yes" />
+    <link rel="stylesheet" href="css/prepend.min.css" />
     <link rel="stylesheet" href="css/app.min.css" />
     <link rel="stylesheet" href="css/responsive.min.css" />
+    <link rel="stylesheet" href="css/append.min.css" />
     <!-- inject:js -->
     <script src="js/app.min.js"></script>
   </head>


### PR DESCRIPTION
While I was trying to use https://github.com/kuhnza/angular-google-places-autocomplete in a project, found that the config.vendor.css files were not used / generated. This PR fixes this.
